### PR TITLE
Balance Tweaks

### DIFF
--- a/Resources/Prototypes/_Wega/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Wega/Catalog/uplink_catalog.yml
@@ -11,7 +11,6 @@
   categories:
   - UplinkExplosives
 
-
 - type: listing
   id: UplinkOverlordCircuitBoard
   name: uplink-overlord-law-name
@@ -37,9 +36,9 @@
   productEntity: SyndicateCircuitBoard
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 12
+    Telecrystal: 11
   cost:
-    Telecrystal: 16
+    Telecrystal: 15
   categories:
   - UplinkDisruption
   conditions:

--- a/Resources/Prototypes/_Wega/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/_Wega/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -4,6 +4,8 @@
   parent: [BasePlasticExplosive, BaseSyndicateContraband]
   id: StickyBomb
   components:
+  - type: Item
+    size: Tiny
   - type: Sprite
     sprite: _Wega/Objects/Weapons/Bombs/stickybomb.rsi
     state: icon

--- a/Resources/Prototypes/_Wega/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/_Wega/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -9,7 +9,7 @@
       types:
         Blunt: 1
   - type: StaminaDamageOnCollide
-    damage: 30
+    damage: 20
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
     layers:


### PR DESCRIPTION
- Урон ППшки донксофт по стамине: 30 -> 20 (~4 попадания -> ~6 попаданий)
- Размер липкой бомбы: 1x2 -> 1x1
- Цена набора законов ИИ Синдикат: 16 -> 15, скидка: 12 -> 11 (Нужно что-бы агент мог за одно купить бинарный ключ шифрования и с остатком взять еще один дополнительный предмет, к примеру ID карту агента.)