### PR TITLE
Распределение Ачивок

### DIFF
--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/AshDrake/AshDrakeSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/AshDrake/AshDrakeSystem.cs
@@ -3,7 +3,6 @@ using System.Numerics;
 using Content.Server.Lavaland.Mobs.Components;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.Systems;
-using Content.Shared.Achievements;
 using Content.Shared.Camera;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
@@ -30,7 +29,6 @@ namespace Content.Server.Lavaland.Mobs;
 
 public sealed partial class AshDrakeSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAchievementsSystem _achievement = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly GibbingSystem _gibbing = default!;

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/AshDrake/AshDrakeSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/AshDrake/AshDrakeSystem.cs
@@ -52,19 +52,9 @@ public sealed partial class AshDrakeSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<AshDrakeBossComponent, MegafaunaKilledEvent>(OnAshDrakeKilled);
-
         SubscribeLocalEvent<AshDrakeBossComponent, AshDrakeConeFireActionEvent>(OnConeFireAction);
         SubscribeLocalEvent<AshDrakeBossComponent, AshDrakeBreathingFireActionEvent>(OnBreathingFireAction);
         SubscribeLocalEvent<AshDrakeBossComponent, AshDrakeLavaActionEvent>(OnLavaAction);
-    }
-
-    private void OnAshDrakeKilled(EntityUid uid, AshDrakeBossComponent component, MegafaunaKilledEvent args)
-    {
-        if (args.Killer == null)
-            return;
-
-        _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.AshDrakeBoss);
     }
 
     #region Cone Fire

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/BloodDrunkMiner/BloodDrunkMinerSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/BloodDrunkMiner/BloodDrunkMinerSystem.cs
@@ -1,5 +1,4 @@
 using Content.Server.Lavaland.Mobs.Components;
-using Content.Shared.Achievements;
 using Content.Shared.Lavaland.Events;
 using Content.Shared.SSDIndicator;
 using Robust.Shared.Audio.Systems;
@@ -8,7 +7,6 @@ namespace Content.Server.Lavaland.Mobs;
 
 public sealed partial class BloodDrunkMinerSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAchievementsSystem _achievement = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/BloodDrunkMiner/BloodDrunkMinerSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/BloodDrunkMiner/BloodDrunkMinerSystem.cs
@@ -18,7 +18,6 @@ public sealed partial class BloodDrunkMinerSystem : EntitySystem
 
         SubscribeLocalEvent<BloodDrunkMinerComponent, MapInitEvent>(OnMapInit);
 
-        SubscribeLocalEvent<BloodDrunkMinerComponent, MegafaunaKilledEvent>(OnBloodDrunkMinerKilled);
         SubscribeLocalEvent<BloodDrunkMinerComponent, BloodDrunkMinerDashAction>(OnDash);
     }
 
@@ -26,14 +25,6 @@ public sealed partial class BloodDrunkMinerSystem : EntitySystem
     private void OnMapInit(Entity<BloodDrunkMinerComponent> ent, ref MapInitEvent args)
     {
         RemComp<SSDIndicatorComponent>(ent);
-    }
-
-    private void OnBloodDrunkMinerKilled(EntityUid uid, BloodDrunkMinerComponent component, MegafaunaKilledEvent args)
-    {
-        if (args.Killer == null)
-            return;
-
-        _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.MinerBoss);
     }
 
     private void OnDash(Entity<BloodDrunkMinerComponent> ent, ref BloodDrunkMinerDashAction args)

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Bubblegum/BubblegumSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Bubblegum/BubblegumSystem.cs
@@ -145,9 +145,6 @@ public sealed partial class BubblegumSystem : EntitySystem
         foreach (var reward in component.RewardsProto)
             Spawn(reward, coords);
 
-        if (args.Killer != null)
-            _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.BubblegumBoss);
-
         QueueDel(uid);
     }
 

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Bubblegum/BubblegumSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Bubblegum/BubblegumSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Lavaland.Mobs.Components;
 using Content.Server.NPC.Components;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.Systems;
-using Content.Shared.Achievements;
 using Content.Shared.Actions.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Damage;
@@ -34,7 +33,6 @@ namespace Content.Server.Lavaland.Mobs;
 
 public sealed partial class BubblegumSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAchievementsSystem _achievement = default!;
     [Dependency] private readonly AppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly DamageableSystem _damage = default!;

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Colossus/ColossusSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Colossus/ColossusSystem.cs
@@ -45,10 +45,6 @@ public sealed class ColossusSystem : EntitySystem
             Spawn(reward, coords);
 
         QueueDel(uid);
-        if (args.Killer != null)
-        {
-            _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.ColossusBoss);
-        }
     }
 
     private void OnFractionAction(Entity<ColossusBossComponent> ent, ref ColossusFractionActionEvent args)

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Colossus/ColossusSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Colossus/ColossusSystem.cs
@@ -1,7 +1,6 @@
 using System.Numerics;
 using Content.Server.Chat.Systems;
 using Content.Server.Lavaland.Mobs.Components;
-using Content.Shared.Achievements;
 using Content.Shared.Chat;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
@@ -18,7 +17,6 @@ namespace Content.Server.Lavaland;
 
 public sealed class ColossusSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAchievementsSystem _achievement = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly SharedGunSystem _gun = default!;

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Hierophant/HierophantSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Hierophant/HierophantSystem.cs
@@ -72,10 +72,6 @@ public sealed partial class HierophantSystem : EntitySystem
             Spawn(reward, coords);
 
         QueueDel(uid);
-        if (args.Killer != null)
-        {
-            _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.HierophantBoss);
-        }
     }
 
     #region Passive Movement

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Hierophant/HierophantSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Hierophant/HierophantSystem.cs
@@ -2,8 +2,6 @@ using System.Numerics;
 using Content.Server.Lavaland.Mobs.Components;
 using Content.Server.NPC.HTN;
 using Content.Server.NPC.Systems;
-using Content.Shared.Achievements;
-using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Lavaland.Components;
 using Content.Shared.Lavaland.Events;
@@ -25,7 +23,6 @@ namespace Content.Server.Lavaland.Mobs;
 /// </summary>
 public sealed partial class HierophantSystem : EntitySystem
 {
-    [Dependency] private readonly SharedAchievementsSystem _achievement = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly IGameTiming _timing = default!;

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Legion/LegionSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Legion/LegionSystem.cs
@@ -260,7 +260,8 @@ public sealed partial class LegionSystem : EntitySystem
             var spawnPos = FindSpawnPositionNear(coords, 2f);
             if (spawnPos != null)
             {
-                Spawn(prototype, spawnPos.Value);
+                var splitEntity = Spawn(prototype, spawnPos.Value);
+                TransferDamageContributors(uid, splitEntity);
             }
         }
 
@@ -285,11 +286,7 @@ public sealed partial class LegionSystem : EntitySystem
                 foreach (var reward in legion.RewardsProto)
                     Spawn(reward, coords);
 
-                if (args.Killer != null)
-                {
-                    _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.FirstBoss);
-                    _achievement.QueueAchievement(args.Killer.Value, AchievementsEnum.LegionBoss);
-                }
+                GrantAchievementsForLegion(uid);
             }
         }
 
@@ -304,7 +301,8 @@ public sealed partial class LegionSystem : EntitySystem
             var spawnPos = FindSpawnPositionNear(coords, 2f);
             if (spawnPos != null)
             {
-                Spawn(component.NextSplitPrototype, spawnPos.Value);
+                var nextSplit = Spawn(component.NextSplitPrototype, spawnPos.Value);
+                TransferDamageContributors(uid, nextSplit);
             }
         }
     }
@@ -322,6 +320,53 @@ public sealed partial class LegionSystem : EntitySystem
                 }
             }
         }
+    }
+
+    private void GrantAchievementsForLegion(EntityUid lastSplit)
+    {
+        if (!TryComp<MegafaunaDamageContributorComponent>(lastSplit, out var contributor))
+            return;
+
+        if (contributor.AchievementsGranted)
+            return;
+
+        contributor.AchievementsGranted = true;
+
+        var totalDamage = contributor.TotalDamageReceived;
+        if (totalDamage <= 0)
+            return;
+
+        var threshold = contributor.Threshold;
+        foreach (var (player, damage) in contributor.Contributors)
+        {
+            var percentage = damage / totalDamage;
+            if (percentage >= threshold)
+            {
+                _achievement.QueueAchievement(player, AchievementsEnum.FirstBoss);
+                _achievement.QueueAchievement(player, AchievementsEnum.LegionBoss);
+            }
+        }
+
+        contributor.Contributors.Clear();
+    }
+
+    private void TransferDamageContributors(EntityUid from, EntityUid to)
+    {
+        if (!TryComp<MegafaunaDamageContributorComponent>(from, out var fromContrib))
+            return;
+
+        var toContrib = EnsureComp<MegafaunaDamageContributorComponent>(to);
+        foreach (var (player, damage) in fromContrib.Contributors)
+        {
+            toContrib.Contributors.TryGetValue(player, out var current);
+            toContrib.Contributors[player] = current + damage;
+        }
+        toContrib.TotalDamageReceived += fromContrib.TotalDamageReceived;
+
+        toContrib.Threshold = fromContrib.Threshold;
+        toContrib.AchievementId = fromContrib.AchievementId;
+
+        fromContrib.Contributors.Clear();
     }
 
     #endregion

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/Legion/LegionSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/Legion/LegionSystem.cs
@@ -8,6 +8,7 @@ using Content.Server.Surgery;
 using Content.Shared.Achievements;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
 using Content.Shared.Height;
 using Content.Shared.Humanoid;
 using Content.Shared.Interaction;
@@ -270,6 +271,8 @@ public sealed partial class LegionSystem : EntitySystem
 
     private void OnSplitKilled(EntityUid uid, LegionSplitComponent component, MegafaunaKilledEvent args)
     {
+        RedistributeDamageToAllSplits(uid);
+
         if (!string.IsNullOrEmpty(component.NextSplitPrototype))
         {
             SplitToNextLevel(uid, component);
@@ -332,7 +335,10 @@ public sealed partial class LegionSystem : EntitySystem
 
         contributor.AchievementsGranted = true;
 
-        var totalDamage = contributor.TotalDamageReceived;
+        FixedPoint2 totalDamage = 0f;
+        foreach (var damage in contributor.Contributors.Values)
+            totalDamage += damage;
+
         if (totalDamage <= 0)
             return;
 
@@ -350,6 +356,37 @@ public sealed partial class LegionSystem : EntitySystem
         contributor.Contributors.Clear();
     }
 
+    private void RedistributeDamageToAllSplits(EntityUid dyingSplit)
+    {
+        if (!TryComp<MegafaunaDamageContributorComponent>(dyingSplit, out var dyingContrib))
+            return;
+
+        var livingSplits = new List<EntityUid>();
+        var allSplits = EntityQueryEnumerator<LegionSplitComponent>();
+        while (allSplits.MoveNext(out var uid, out _))
+        {
+            if (uid == dyingSplit || Exists(uid))
+                continue;
+
+            livingSplits.Add(uid);
+        }
+
+        if (livingSplits.Count == 0)
+            return;
+
+        foreach (var living in livingSplits)
+        {
+            var livingContrib = EnsureComp<MegafaunaDamageContributorComponent>(living);
+            foreach (var (player, damage) in dyingContrib.Contributors)
+            {
+                livingContrib.Contributors.TryGetValue(player, out var current);
+                livingContrib.Contributors[player] = current + damage;
+            }
+
+            livingContrib.Threshold = dyingContrib.Threshold;
+        }
+    }
+
     private void TransferDamageContributors(EntityUid from, EntityUid to)
     {
         if (!TryComp<MegafaunaDamageContributorComponent>(from, out var fromContrib))
@@ -361,12 +398,9 @@ public sealed partial class LegionSystem : EntitySystem
             toContrib.Contributors.TryGetValue(player, out var current);
             toContrib.Contributors[player] = current + damage;
         }
-        toContrib.TotalDamageReceived += fromContrib.TotalDamageReceived;
 
         toContrib.Threshold = fromContrib.Threshold;
         toContrib.AchievementId = fromContrib.AchievementId;
-
-        fromContrib.Contributors.Clear();
     }
 
     #endregion

--- a/Content.Server/_Wega/Lavaland/Systems/Mobs/MegafaunaSystem.cs
+++ b/Content.Server/_Wega/Lavaland/Systems/Mobs/MegafaunaSystem.cs
@@ -40,6 +40,19 @@ public sealed partial class MegafaunaSystem : EntitySystem
         if (!component.IsActive && totalDamage > 0)
             ActivateMegafauna(uid, component);
 
+        if (args.Origin != null && HasComp<ActorComponent>(args.Origin))
+        {
+            var damageContributor = EnsureComp<MegafaunaDamageContributorComponent>(uid);
+
+            var damageDelta = args.DamageDelta?.GetTotal() ?? 0f;
+            if (damageDelta > 0)
+            {
+                damageContributor.Contributors.TryGetValue(args.Origin.Value, out var current);
+                damageContributor.Contributors[args.Origin.Value] = current + damageDelta;
+                damageContributor.TotalDamageReceived += damageDelta;
+            }
+        }
+
         if (TryComp<HTNComponent>(uid, out var htn) && args.Origin != null)
             htn.Blackboard.SetValue(component.TargetKey, args.Origin.Value);
     }
@@ -48,6 +61,8 @@ public sealed partial class MegafaunaSystem : EntitySystem
     {
         if (args.NewMobState != MobState.Dead)
             return;
+
+        GrantAchievementsToContributors(uid);
 
         HandleDeath(uid, args);
     }
@@ -69,13 +84,42 @@ public sealed partial class MegafaunaSystem : EntitySystem
         _npc.WakeNPC(uid);
     }
 
+    private void GrantAchievementsToContributors(EntityUid megafaunaUid)
+    {
+        if (HasComp<LegionBossComponent>(megafaunaUid)) // Specific
+            return;
+
+        if (!TryComp<MegafaunaDamageContributorComponent>(megafaunaUid, out var contributor))
+            return;
+
+        if (contributor.AchievementsGranted)
+            return;
+
+        contributor.AchievementsGranted = true;
+
+        var totalDamage = contributor.TotalDamageReceived;
+        if (totalDamage <= 0)
+            return;
+
+        var threshold = contributor.Threshold;
+        var achievementId = contributor.AchievementId;
+
+        foreach (var (player, damage) in contributor.Contributors)
+        {
+            var percentage = damage / totalDamage;
+            if (percentage >= threshold)
+            {
+                _achievement.QueueAchievement(player, achievementId);
+                _achievement.QueueAchievement(player, AchievementsEnum.FirstBoss);
+            }
+        }
+
+        contributor.Contributors.Clear();
+    }
+
     private void HandleDeath(EntityUid uid, MobStateChangedEvent args)
     {
         _ambient.SetAmbience(uid, false);
-        if (args.Origin != null && !HasComp<LegionBossComponent>(uid))
-        {
-            _achievement.QueueAchievement(args.Origin.Value, AchievementsEnum.FirstBoss);
-        }
 
         var killedEvent = new MegafaunaKilledEvent
         {

--- a/Content.Shared/_Wega/Lavaland/Components/Mobs/MegafaunaDamageContributorComponent.cs
+++ b/Content.Shared/_Wega/Lavaland/Components/Mobs/MegafaunaDamageContributorComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.Achievements;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared.Lavaland.Components;
+
+[RegisterComponent]
+public sealed partial class MegafaunaDamageContributorComponent : Component
+{
+    [DataField("achievement", required: true)]
+    public AchievementsEnum AchievementId = default!;
+
+    [DataField]
+    public float Threshold = 0.3f;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public bool AchievementsGranted = false;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public FixedPoint2 TotalDamageReceived = 0f;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<EntityUid, FixedPoint2> Contributors = new();
+}

--- a/Resources/Prototypes/_Wega/Entities/Mobs/NPCs/lavaland_megafauna.yml
+++ b/Resources/Prototypes/_Wega/Entities/Mobs/NPCs/lavaland_megafauna.yml
@@ -115,6 +115,8 @@
     minSaturation: -4.0
     updateIntervalMultiplier: 0.8
   - type: BloodDrunkMiner
+  - type: MegafaunaDamageContributor
+    achievement: MinerBoss
   - type: NPCHandSwitcher
   - type: HTN
     rootTask:
@@ -213,6 +215,8 @@
     rewards:
     - HierophantClubRod
     - GemCompactedDilithium
+  - type: MegafaunaDamageContributor
+    achievement: HierophantBoss
   - type: HTN
     rootTask:
       task: HierophantBehaviorCompound
@@ -299,6 +303,8 @@
       LegionCore: 0.1
     rewards:
     - CrowbarRed
+  - type: MegafaunaDamageContributor
+    achievement: LegionBoss
   - type: TrophyHunter
     trophy: TrophyLavalandLegionSkull
 
@@ -504,6 +510,8 @@
   - type: ColossusBoss
     rewards:
     - CrateNecropolisColossusFilled
+  - type: MegafaunaDamageContributor
+    achievement: ColossusBoss
   - type: HTN
     rootTask:
       task: MegafaunaBehaviorCompound
@@ -600,6 +608,8 @@
     defaultDesc: nav-map-beacon-lavaland-signal-ashdrake-desc
     color: "#a7000b"
   - type: AshDrakeBoss
+  - type: MegafaunaDamageContributor
+    achievement: AshDrakeBoss
   - type: HTN
     rootTask:
       task: MegafaunaBehaviorCompound
@@ -766,6 +776,8 @@
       ActionBubblegumIllusionDash: 0.67
       ActionBubblegumPentagramDash: 0.33
       ActionBubblegumChaoticIllusionDash: 0.75
+  - type: MegafaunaDamageContributor
+    achievement: BubblegumBoss
   - type: HTN
     rootTask:
       task: MegafaunaBehaviorCompound


### PR DESCRIPTION
## Описание PR
Добавлен учет вклада игрока/игроков в убийство боссов
Теперь ачивки выдает не только тому кто добил босса последним ударом, а всем кто нанес хотябы 30% вклада в урон для его убийства

## Почему / Баланс
Более логичное распределение ачивок при убийстве боссов

P.S. Если условного босса будут убивать 5 шахтёров и все нанесут равное количество урона, то это не будет зачтено в итоге. Расчёт идет на 2-3 игрока при равном распределение КПД в плане убийства босса, так что наверняка не выйдет попросту нанести 1 удар и отлежаться, пока твой друг робаст изничтожает мегафауну