### PR TITLE
Обновление Позинга

### DIFF
--- a/Content.Client/_Wega/Posing/PosingSystem.cs
+++ b/Content.Client/_Wega/Posing/PosingSystem.cs
@@ -1,5 +1,6 @@
-using Content.Shared.Posing;
+using System.Numerics;
 using Content.Shared.Input;
+using Content.Shared.Posing;
 using Robust.Client.GameObjects;
 using Robust.Client.Input;
 using Robust.Client.Player;
@@ -12,10 +13,20 @@ public sealed partial class PosingSystem : SharedPosingSystem
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly SpriteSystem _sprite = default!;
 
+    private readonly Dictionary<EntityUid, (
+        Vector2 Offset,
+        Angle Angle,
+        Vector2 TargetOffset,
+        Angle TargetAngle,
+        float LerpTime,
+        bool IsReturning
+    )> _interpolationState = new();
+
     public override void Initialize()
     {
         base.Initialize();
 
+        SubscribeLocalEvent<PosingComponent, ComponentRemove>(OnComponentRemove);
         SubscribeLocalEvent<PosingComponent, AfterAutoHandleStateEvent>(OnAfterHandleState);
 
         var posing = _input.Contexts.New("posing", "common");
@@ -28,34 +39,6 @@ public sealed partial class PosingSystem : SharedPosingSystem
         posing.AddFunction(ContentKeyFunctions.PosingRotateNegative);
     }
 
-    public override void Shutdown()
-    {
-        base.Shutdown();
-        _input.Contexts.Remove("posing");
-    }
-
-    private void OnAfterHandleState(EntityUid uid, PosingComponent component, ref AfterAutoHandleStateEvent args)
-    {
-        if (_playerManager.LocalEntity == uid)
-            return;
-
-        if (!component.Posing)
-        {
-            _sprite.SetOffset(uid, component.DefaultOffset);
-            _sprite.SetRotation(uid, Angle.FromDegrees(component.DefaultAngle));
-            return;
-        }
-    }
-
-    protected override void ClientTogglePosing(EntityUid uid, PosingComponent posing)
-    {
-        base.ClientTogglePosing(uid, posing);
-
-        _input.Contexts.SetActiveContext(posing.Posing ? "posing" : posing.DefaultInputContext);
-        _sprite.SetOffset(uid, posing.DefaultOffset);
-        _sprite.SetRotation(uid, Angle.FromDegrees(posing.DefaultAngle));
-    }
-
     public override void FrameUpdate(float frameTime)
     {
         base.FrameUpdate(frameTime);
@@ -65,9 +48,178 @@ public sealed partial class PosingSystem : SharedPosingSystem
         {
             if (posing.Posing)
             {
-                _sprite.SetOffset(uid, posing.DefaultOffset + posing.CurrentOffset);
-                _sprite.SetRotation(uid, posing.CurrentAngle);
+                if (!_interpolationState.TryGetValue(uid, out var state))
+                {
+                    state = (
+                        posing.CurrentOffset,
+                        posing.CurrentAngle,
+                        posing.CurrentOffset,
+                        posing.CurrentAngle,
+                        0f,
+                        false
+                    );
+                    _interpolationState[uid] = state;
+                }
+
+                if (state.IsReturning)
+                {
+                    state = (
+                        posing.CurrentOffset,
+                        posing.CurrentAngle,
+                        posing.CurrentOffset,
+                        posing.CurrentAngle,
+                        0f,
+                        false
+                    );
+                }
+
+                if (state.TargetOffset != posing.CurrentOffset || state.TargetAngle != posing.CurrentAngle)
+                {
+                    state.TargetOffset = posing.CurrentOffset;
+                    state.TargetAngle = posing.CurrentAngle;
+                    state.LerpTime = 0f;
+                }
+
+                state.LerpTime += frameTime;
+                var t = Math.Min(1f, state.LerpTime / 0.15f);
+
+                var newOffset = Vector2.Lerp(state.Offset, state.TargetOffset, t);
+                var newAngle = Angle.FromDegrees(
+                    MathHelper.Lerp(state.Angle.Degrees, state.TargetAngle.Degrees, t)
+                );
+
+                if (t >= 1f)
+                {
+                    state.Offset = state.TargetOffset;
+                    state.Angle = state.TargetAngle;
+                }
+                else
+                {
+                    state.Offset = newOffset;
+                    state.Angle = newAngle;
+                }
+
+                _sprite.SetOffset(uid, posing.DefaultOffset + state.Offset);
+                _sprite.SetRotation(uid, state.Angle);
+
+                _interpolationState[uid] = state;
             }
+            else
+            {
+                if (_interpolationState.TryGetValue(uid, out var state))
+                {
+                    if (!state.IsReturning)
+                    {
+                        state.IsReturning = true;
+                        state.LerpTime = 0f;
+                        state.TargetOffset = Vector2.Zero;
+                        state.TargetAngle = Angle.Zero;
+                    }
+
+                    state.LerpTime += frameTime;
+                    var t = Math.Min(1f, state.LerpTime / 0.2f);
+
+                    var newOffset = Vector2.Lerp(state.Offset, state.TargetOffset, t);
+                    var newAngle = Angle.FromDegrees(
+                        MathHelper.Lerp(state.Angle.Degrees, state.TargetAngle.Degrees, t)
+                    );
+
+                    if (t >= 1f)
+                    {
+                        _interpolationState.Remove(uid);
+                        _sprite.SetOffset(uid, posing.DefaultOffset);
+                        _sprite.SetRotation(uid, Angle.FromDegrees(posing.DefaultAngle));
+                    }
+                    else
+                    {
+                        state.Offset = newOffset;
+                        state.Angle = newAngle;
+                        _interpolationState[uid] = state;
+                        _sprite.SetOffset(uid, posing.DefaultOffset + state.Offset);
+                        _sprite.SetRotation(uid, state.Angle);
+                    }
+                }
+            }
+        }
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+        _input.Contexts.Remove("posing");
+        _interpolationState.Clear();
+    }
+
+    protected override void TogglePosing(Entity<PosingComponent?> entity)
+    {
+        base.TogglePosing(entity);
+
+        if (!Resolve(entity, ref entity.Comp, false))
+            return;
+
+        _input.Contexts.SetActiveContext(entity.Comp.Posing ? "posing" : entity.Comp.DefaultInputContext);
+
+        if (entity.Comp.Posing)
+        {
+            _interpolationState[entity.Owner] = (
+                entity.Comp.CurrentOffset,
+                entity.Comp.CurrentAngle,
+                entity.Comp.CurrentOffset,
+                entity.Comp.CurrentAngle,
+                0f, false
+            );
+            _sprite.SetOffset(entity.Owner, entity.Comp.DefaultOffset + entity.Comp.CurrentOffset);
+            _sprite.SetRotation(entity.Owner, entity.Comp.CurrentAngle);
+        }
+        else
+        {
+            if (_interpolationState.TryGetValue(entity.Owner, out var state))
+            {
+                state.IsReturning = true;
+                state.LerpTime = 0f;
+                state.TargetOffset = Vector2.Zero;
+                state.TargetAngle = Angle.Zero;
+                _interpolationState[entity.Owner] = state;
+            }
+        }
+    }
+
+    private void OnComponentRemove(EntityUid uid, PosingComponent component, ComponentRemove args)
+    {
+        _interpolationState.Remove(uid);
+    }
+
+    private void OnAfterHandleState(EntityUid uid, PosingComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        if (_playerManager.LocalEntity == uid)
+            return;
+
+        if (component.Posing && _interpolationState.TryGetValue(uid, out var state))
+        {
+            state.TargetOffset = component.CurrentOffset;
+            state.TargetAngle = component.CurrentAngle;
+            state.LerpTime = 0f;
+            state.IsReturning = false;
+            _interpolationState[uid] = state;
+        }
+        else if (component.Posing && !_interpolationState.ContainsKey(uid))
+        {
+            _interpolationState[uid] = (
+                component.CurrentOffset,
+                component.CurrentAngle,
+                component.CurrentOffset,
+                component.CurrentAngle,
+                0f, false
+            );
+        }
+        else if (!component.Posing && _interpolationState.ContainsKey(uid) && !_interpolationState[uid].IsReturning)
+        {
+            var returnState = _interpolationState[uid];
+            returnState.IsReturning = true;
+            returnState.LerpTime = 0f;
+            returnState.TargetOffset = Vector2.Zero;
+            returnState.TargetAngle = Angle.Zero;
+            _interpolationState[uid] = returnState;
         }
     }
 }

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -69,13 +69,15 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction ZoomIn = "ZoomIn";
         public static readonly BoundKeyFunction ResetZoom = "ResetZoom";
 
-        public static readonly BoundKeyFunction TogglePosing = "TogglePosing"; // Corvax-Wega-Posing
-        public static readonly BoundKeyFunction PosingOffsetLeft = "PosingOffsetLeft"; // Corvax-Wega-Posing
-        public static readonly BoundKeyFunction PosingOffsetRight = "PosingOffsetRight"; // Corvax-Wega-Posing
-        public static readonly BoundKeyFunction PosingOffsetUp = "PosingOffsetUp"; // Corvax-Wega-Posing
-        public static readonly BoundKeyFunction PosingOffsetDown = "PosingOffsetDown"; // Corvax-Wega-Posing
-        public static readonly BoundKeyFunction PosingRotateNegative = "PosingRotateNegative"; // Corvax-Wega-Posing
-        public static readonly BoundKeyFunction PosingRotatePositive = "PosingRotatePositive"; // Corvax-Wega-Posing
+        // Corvax-Wega-Posing-start
+        public static readonly BoundKeyFunction TogglePosing = "TogglePosing";
+        public static readonly BoundKeyFunction PosingOffsetLeft = "PosingOffsetLeft";
+        public static readonly BoundKeyFunction PosingOffsetRight = "PosingOffsetRight";
+        public static readonly BoundKeyFunction PosingOffsetUp = "PosingOffsetUp";
+        public static readonly BoundKeyFunction PosingOffsetDown = "PosingOffsetDown";
+        public static readonly BoundKeyFunction PosingRotateNegative = "PosingRotateNegative";
+        public static readonly BoundKeyFunction PosingRotatePositive = "PosingRotatePositive";
+        // Corvax-Wega-Posing-end
 
         public static readonly BoundKeyFunction ArcadeUp = "ArcadeUp";
         public static readonly BoundKeyFunction ArcadeDown = "ArcadeDown";

--- a/Content.Shared/_Wega/Posing/PosingComponent.cs
+++ b/Content.Shared/_Wega/Posing/PosingComponent.cs
@@ -3,14 +3,18 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared.Posing;
 
+[Access(typeof(SharedPosingSystem))]
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class PosingComponent : Component
 {
-    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public Vector2 CurrentOffset = Vector2.Zero;
 
-    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
     public Angle CurrentAngle = Angle.Zero;
+
+    [ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public bool Posing = false;
 
     [DataField, AutoNetworkedField]
     public Vector2 OffsetLimits = new(0.3f, 0.3f);
@@ -18,10 +22,7 @@ public sealed partial class PosingComponent : Component
     [DataField, AutoNetworkedField]
     public float AngleLimits = 180f;
 
-    [ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
-    public bool Posing = false;
-
-    [DataField]
+    [DataField("defaultInput")]
     public string DefaultInputContext = "human";
 
     [DataField]

--- a/Content.Shared/_Wega/Posing/SharedPosingSystem.cs
+++ b/Content.Shared/_Wega/Posing/SharedPosingSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Damage.Components;
 using Content.Shared.Input;
 using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
@@ -18,6 +19,7 @@ public abstract partial class SharedPosingSystem : EntitySystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
     private readonly Dictionary<EntityUid, (float Angle, float OffsetX, float OffsetY, TimeSpan LastUpdate)> _continuousInput = new();
@@ -177,6 +179,9 @@ public abstract partial class SharedPosingSystem : EntitySystem
 
     private bool CanTogglePosing(EntityUid uid)
     {
+        if (!_mobState.IsAlive(uid))
+            return false;
+
         if (!_actionBlocker.CanConsciouslyPerformAction(uid))
             return false;
 

--- a/Content.Shared/_Wega/Posing/SharedPosingSystem.cs
+++ b/Content.Shared/_Wega/Posing/SharedPosingSystem.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Damage.Components;
@@ -6,73 +7,42 @@ using Content.Shared.Mobs;
 using Content.Shared.Movement.Events;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
+using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Posing;
 
 public abstract partial class SharedPosingSystem : EntitySystem
 {
-    [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private readonly Dictionary<EntityUid, (float Angle, float OffsetX, float OffsetY, TimeSpan LastUpdate)> _continuousInput = new();
 
     public override void Initialize()
     {
         base.Initialize();
 
-        SubscribeLocalEvent<PosingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
         SubscribeLocalEvent<PosingComponent, DownedEvent>(OnDowned);
+        SubscribeLocalEvent<PosingComponent, UpdateCanMoveEvent>(OnUpdateCanMove);
         SubscribeLocalEvent<PosingComponent, MobStateChangedEvent>(OnMobStateChanged);
 
+        BindCommands();
+    }
+
+    private void BindCommands()
+    {
         CommandBinds.Builder
-            .Bind(ContentKeyFunctions.TogglePosing,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid && !CanTogglePosing(userUid))
-                            TogglePosing(userUid);
-                    },
-                    handle: false))
-            .Bind(ContentKeyFunctions.PosingOffsetRight,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid)
-                            TryAdjustPosingOffset(userUid, new(0.05f, 0f));
-                    },
-                    handle: false))
-            .Bind(ContentKeyFunctions.PosingOffsetLeft,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid)
-                            TryAdjustPosingOffset(userUid, new(-0.05f, 0f));
-                    },
-                    handle: false))
-            .Bind(ContentKeyFunctions.PosingOffsetUp,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid)
-                            TryAdjustPosingOffset(userUid, new(0f, 0.05f));
-                    },
-                    handle: false))
-            .Bind(ContentKeyFunctions.PosingOffsetDown,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid)
-                            TryAdjustPosingOffset(userUid, new(0f, -0.05f));
-                    },
-                    handle: false))
-            .Bind(ContentKeyFunctions.PosingRotatePositive,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid)
-                            TryAdjustPosingAngle(userUid, -5f);
-                    },
-                    handle: false))
-            .Bind(ContentKeyFunctions.PosingRotateNegative,
-                InputCmdHandler.FromDelegate(session =>
-                    {
-                        if (session?.AttachedEntity is { } userUid)
-                            TryAdjustPosingAngle(userUid, 5f);
-                    },
-                    handle: false))
+            .Bind(ContentKeyFunctions.TogglePosing, new TogglePosingCmdHandler(this))
+            .Bind(ContentKeyFunctions.PosingOffsetRight, new ContinuousOffsetHandler(this, 0.2f, 0))
+            .Bind(ContentKeyFunctions.PosingOffsetLeft, new ContinuousOffsetHandler(this, -0.2f, 0))
+            .Bind(ContentKeyFunctions.PosingOffsetUp, new ContinuousOffsetHandler(this, 0, 0.2f))
+            .Bind(ContentKeyFunctions.PosingOffsetDown, new ContinuousOffsetHandler(this, 0, -0.2f))
+            .Bind(ContentKeyFunctions.PosingRotatePositive, new ContinuousAngleHandler(this, -20f))
+            .Bind(ContentKeyFunctions.PosingRotateNegative, new ContinuousAngleHandler(this, 20f))
             .Register<SharedPosingSystem>();
     }
 
@@ -80,55 +50,91 @@ public abstract partial class SharedPosingSystem : EntitySystem
     {
         base.Shutdown();
         CommandBinds.Unregister<SharedPosingSystem>();
+        _continuousInput.Clear();
     }
 
-    private void OnUpdateCanMove(EntityUid uid, PosingComponent component, UpdateCanMoveEvent args)
+    public override void Update(float frameTime)
     {
-        if (component.Posing)
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+        foreach (var (uid, input) in _continuousInput.ToArray())
+        {
+            if (!TryComp<PosingComponent>(uid, out var posing) || !posing.Posing)
+            {
+                _continuousInput.Remove(uid);
+                continue;
+            }
+
+            var timeSinceLastUpdate = now - input.LastUpdate;
+            if (timeSinceLastUpdate.TotalSeconds < 0.016) // 60 FPS
+                continue;
+
+            var delta = Math.Min(0.1f, (float)timeSinceLastUpdate.TotalSeconds);
+
+            if (input.Angle != 0)
+                TryAdjustPosingAngle(uid, input.Angle * delta, posing);
+
+            if (input.OffsetX != 0 || input.OffsetY != 0)
+                TryAdjustPosingOffset(uid, new Vector2(input.OffsetX, input.OffsetY) * delta, posing);
+
+            _continuousInput[uid] = (input.Angle, input.OffsetX, input.OffsetY, now);
+        }
+    }
+
+    #region  Continuous Input
+    private void StartContinuous(EntityUid uid, float angle = 0, float offsetX = 0, float offsetY = 0)
+    {
+        if (!HasComp<PosingComponent>(uid))
+            return;
+
+        _continuousInput[uid] = (angle, offsetX, offsetY, _timing.CurTime);
+    }
+
+    private void StopContinuous(EntityUid uid)
+    {
+        _continuousInput.Remove(uid);
+    }
+    #endregion
+
+    #region Event Handlers
+    private void OnDowned(Entity<PosingComponent> ent, ref DownedEvent args)
+    {
+        if (!ent.Comp.Posing)
+            return;
+
+        TogglePosing((ent.Owner, ent.Comp));
+    }
+
+    private void OnUpdateCanMove(Entity<PosingComponent> ent, ref UpdateCanMoveEvent args)
+    {
+        if (ent.Comp.Posing)
             args.Cancel();
     }
 
-    private void OnDowned(EntityUid uid, PosingComponent component, EntityEventArgs args)
+    private void OnMobStateChanged(Entity<PosingComponent> ent, ref MobStateChangedEvent args)
     {
-        if (component.Posing)
-            TogglePosing(uid, component);
-    }
-
-    private void OnMobStateChanged(EntityUid uid, PosingComponent component, ref MobStateChangedEvent args)
-    {
-        if (component.Posing)
-            TogglePosing(uid, component);
-    }
-
-    private void TogglePosing(EntityUid uid, PosingComponent? posingComp = null)
-    {
-        if (!Resolve(uid, ref posingComp, false))
+        if (!ent.Comp.Posing)
             return;
 
-        posingComp.Posing = !posingComp.Posing;
-        _actionBlocker.UpdateCanMove(uid);
-
-        posingComp.CurrentAngle = Angle.Zero;
-        posingComp.CurrentOffset = Vector2.Zero;
-
-        ClientTogglePosing(uid, posingComp);
-        Dirty(uid, posingComp);
+        TogglePosing((ent.Owner, ent.Comp));
     }
+    #endregion
 
+    #region Adjustment Methods
     private void TryAdjustPosingOffset(EntityUid uid, Vector2 offset, PosingComponent? posingComp = null)
     {
         if (!Resolve(uid, ref posingComp, false) || !posingComp.Posing)
             return;
 
-        var previousOffset = posingComp.CurrentOffset;
+        var newOffset = posingComp.CurrentOffset + offset;
+        newOffset = Vector2.Clamp(newOffset, -posingComp.OffsetLimits, posingComp.OffsetLimits);
 
-        posingComp.CurrentOffset += offset;
-        posingComp.CurrentOffset = Vector2.Clamp(posingComp.CurrentOffset, -posingComp.OffsetLimits, posingComp.OffsetLimits);
-
-        if (posingComp.CurrentOffset.Equals(previousOffset))
-            return;
-
-        Dirty(uid, posingComp);
+        if (Vector2.Distance(posingComp.CurrentOffset, newOffset) > 0.0001f)
+        {
+            posingComp.CurrentOffset = newOffset;
+            Dirty(uid, posingComp);
+        }
     }
 
     private void TryAdjustPosingAngle(EntityUid uid, float angle, PosingComponent? posingComp = null)
@@ -136,24 +142,42 @@ public abstract partial class SharedPosingSystem : EntitySystem
         if (!Resolve(uid, ref posingComp, false) || !posingComp.Posing)
             return;
 
-        var previousAngle = posingComp.CurrentAngle;
-
         var newAngle = posingComp.CurrentAngle.Degrees + angle;
-        posingComp.CurrentAngle = Angle.FromDegrees(Math.Clamp(newAngle, -posingComp.AngleLimits, posingComp.AngleLimits));
+        var clampedAngle = Math.Clamp(newAngle, -posingComp.AngleLimits, posingComp.AngleLimits);
 
-        if (posingComp.CurrentAngle.Equals(previousAngle))
+        if (Math.Abs(posingComp.CurrentAngle.Degrees - clampedAngle) > 0.01f)
+        {
+            posingComp.CurrentAngle = Angle.FromDegrees(clampedAngle);
+            Dirty(uid, posingComp);
+        }
+    }
+    #endregion
+
+    #region Core Logic
+    protected virtual void TogglePosing(Entity<PosingComponent?> entity)
+    {
+        if (!Resolve(entity, ref entity.Comp, false))
             return;
 
-        Dirty(uid, posingComp);
-    }
+        entity.Comp.Posing = !entity.Comp.Posing;
+        _actionBlocker.UpdateCanMove(entity.Owner);
 
-    protected virtual void ClientTogglePosing(EntityUid uid, PosingComponent posing)
-    {
+        if (entity.Comp.Posing)
+        {
+            entity.Comp.CurrentOffset = Vector2.Zero;
+            entity.Comp.CurrentAngle = Angle.Zero;
+        }
+        else
+        {
+            _continuousInput.Remove(entity.Owner);
+        }
+
+        Dirty(entity);
     }
 
     private bool CanTogglePosing(EntityUid uid)
     {
-        if (_actionBlocker.CanConsciouslyPerformAction(uid))
+        if (!_actionBlocker.CanConsciouslyPerformAction(uid))
             return false;
 
         if (TryComp<StaminaComponent>(uid, out var stamina) && stamina.Critical)
@@ -167,4 +191,76 @@ public abstract partial class SharedPosingSystem : EntitySystem
 
         return true;
     }
+    #endregion
+
+    #region Command Handlers
+    private sealed class TogglePosingCmdHandler : InputCmdHandler
+    {
+        private readonly SharedPosingSystem _system;
+        public TogglePosingCmdHandler(SharedPosingSystem system) => _system = system;
+
+        public override bool HandleCmdMessage(IEntityManager entManager, ICommonSession? session, IFullInputCmdMessage message)
+        {
+            if (session?.AttachedEntity is not { } uid || message.State != BoundKeyState.Down)
+                return false;
+
+            if (_system.CanTogglePosing(uid))
+                _system.TogglePosing(uid);
+
+            return false;
+        }
+    }
+
+    private sealed class ContinuousOffsetHandler : InputCmdHandler
+    {
+        private readonly SharedPosingSystem _system;
+        private readonly float _offsetX;
+        private readonly float _offsetY;
+
+        public ContinuousOffsetHandler(SharedPosingSystem system, float offsetX, float offsetY)
+        {
+            _system = system;
+            _offsetX = offsetX;
+            _offsetY = offsetY;
+        }
+
+        public override bool HandleCmdMessage(IEntityManager entManager, ICommonSession? session, IFullInputCmdMessage message)
+        {
+            if (session?.AttachedEntity is not { } uid)
+                return false;
+
+            if (message.State == BoundKeyState.Down)
+                _system.StartContinuous(uid, offsetX: _offsetX, offsetY: _offsetY);
+            else if (message.State == BoundKeyState.Up)
+                _system.StopContinuous(uid);
+
+            return false;
+        }
+    }
+
+    private sealed class ContinuousAngleHandler : InputCmdHandler
+    {
+        private readonly SharedPosingSystem _system;
+        private readonly float _angle;
+
+        public ContinuousAngleHandler(SharedPosingSystem system, float angle)
+        {
+            _system = system;
+            _angle = angle;
+        }
+
+        public override bool HandleCmdMessage(IEntityManager entManager, ICommonSession? session, IFullInputCmdMessage message)
+        {
+            if (session?.AttachedEntity is not { } uid)
+                return false;
+
+            if (message.State == BoundKeyState.Down)
+                _system.StartContinuous(uid, angle: _angle);
+            else if (message.State == BoundKeyState.Up)
+                _system.StopContinuous(uid);
+
+            return false;
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Описание PR
Улучшена сама структура кода позинга
Исправлена логическая ошибка из-за которой проверка на условия для переключения была инвернутая, то есть наоборот

Обновления от меня:
Мне показалось, что постоянно нажимать клавиши не удобно, да и перемещение слегка дерганное. Поэтому теперь для перемещения вы можете зажимать клавиши и само передвижение будет постепенным и плавным, а также имеющим инерцию, то есть не затухающую сразу по отпусканию клавиши
Другие игроки будут также видеть ваше постепенное движение

Так же теперь при переключении позиционирование персонаж будет не мгновенно возвращаться в исходную позицию, а постепенно и плавно

Единственный минус такого подхода, при переходе из разных состояний персонаж может остаться в том положении в котором был, без перехода в лежачее визуально, но не более
Мне стало в падлу это дорабатывать, так что пусть будет так все равно это не частые случаи не столько критично

---

_Не претендую на авторство данных улучшений, так что используйте как хотите в пределах лицензии (GPL/AGPL)_

## Почему / Баланс
Как говорил ранее я видел как можно доработать, я доработал

## Медиа
![2026-04-10 13-36-08](https://github.com/user-attachments/assets/a480eff7-2a2e-4eba-86e9-e4e84cc3d4da)