### PR TITLE
Добавление в режим ксеноборгов новых модулей

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/xenoborgs.yml
@@ -187,7 +187,7 @@
   - type: MovementAlwaysTouching # it flies in space with tiny thrusters
   - type: FlashImmunity
   - type: BorgChassis
-    maxModules: 4
+    maxModules: 5 # Corvax-Wega-Edit 4 - > 5
     hasMindState: xenoborg_scout_e
     noMindState: xenoborg_scout_e_r
     moduleWhitelist:
@@ -206,6 +206,7 @@
       - XenoborgModuleTool
       - XenoborgModuleSword
       - XenoborgModuleSpaceMovement
+      - XenoborgModuleJump # Corvax-Wega-add
   - type: ItemSlots
     slots:
       cell_slot:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/xenoborgs.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/xenoborgs.yml
@@ -24,4 +24,5 @@
   - XenoborgModuleCommonSpeed
   - XenoborgModuleEMP
   - BorgModuleNightVisoXenoborg
+  - XenoborgModuleTileGun
 # Corvax-Wega-start

--- a/Resources/Prototypes/_Wega/Recipes/Lathes/xenoborg.yml
+++ b/Resources/Prototypes/_Wega/Recipes/Lathes/xenoborg.yml
@@ -39,3 +39,12 @@
   materials:
     Steel: 1500
     Glass: 1500
+
+- type: latheRecipe
+  parent: BaseXenoborgModulesRecipe
+  id: XenoborgModuleTileGun
+  result: XenoborgModuleTileGun
+  materials:
+    Steel: 1500
+    Glass: 1500
+    


### PR DESCRIPTION
## Описание PR
1. Визы добавили модуль плиткострела и прыжкового модуля, однако в сам режим нет ( типа для будущего обновы и тп ), пока это далекое будущее не наступило, раундстартом добавил разведчику прыжковый модуль ( макс модулей увеличино с 4 до 5 ), а инж ксеноборг получил возможность печатать в ядре ксеноматери плиткомет

## Почему / Баланс
Лучше люди сейчас с этим поиграют, чем будут ждать полгода релиза всех идей по новым модулям
