### PR TITLE
Arirals, shrimp, and Lizards

### DIFF
--- a/Resources/Locale/ru-RU/_wega/reagents/meta/consumable/food/food.ftl
+++ b/Resources/Locale/ru-RU/_wega/reagents/meta/consumable/food/food.ftl
@@ -1,2 +1,4 @@
 reagent-name-shrimp = креветка
 reagent-desc-shrimp = Малый морской ракообразный, съедобное мясо с мягким вкусом.
+reagent-name-cooked-shrimp = приготовленная креветка
+reagent-desc-cooked-shrimp = Приготовленное и готовое к употреблению мясо морского ракообразного.

--- a/Resources/Prototypes/Body/Species/reptilian.yml
+++ b/Resources/Prototypes/Body/Species/reptilian.yml
@@ -364,6 +364,11 @@
       - Pill
       - Crayon
       - Paper
+      # Corvax-Wega-start
+      - Salad 
+      - Vegetable
+      - Soup
+      # Corvax-Wega-end
 
 - type: entity
   parent: [ OrganBaseLiver, OrganSpriteHumanInternal, OrganReptilianInternal, OrganReptilianMetabolizer ]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/noodles.yml
@@ -17,6 +17,11 @@
       reagents:
       - ReagentId: Nutriment
         Quantity: 30
+  # Corvax-Wega-start
+  - type: Tag
+    tags:
+    - ReptilianFood
+  # Corvax-Wega-end
 
 # Noodles
 

--- a/Resources/Prototypes/_Wega/Body/Species/ariral.yml
+++ b/Resources/Prototypes/_Wega/Body/Species/ariral.yml
@@ -303,8 +303,11 @@
   id: OrganAriralLungs
 
 - type: entity
-  parent: [ OrganBaseHeart, OrganAriralInternal, OrganAriralMetabolizer ]
+  parent: [ OrganBaseHeart, OrganAriralInternal]
   id: OrganAriralHeart
+  components:
+  - type: Metabolizer
+    metabolizerTypes: [ Ariral ]
 
 - type: entity
   parent: [ OrganBaseStomach, OrganAriralInternal ]

--- a/Resources/Prototypes/_Wega/Body/Species/ariral.yml
+++ b/Resources/Prototypes/_Wega/Body/Species/ariral.yml
@@ -199,7 +199,7 @@
   abstract: true
   components:
   - type: Metabolizer
-    metabolizerTypes: [ Human ]
+    metabolizerTypes: [ Ariral ]
 
 - type: entity
   parent: OrganAriral
@@ -299,27 +299,21 @@
   id: OrganAriralEars
 
 - type: entity
-  parent: [ OrganBaseLungs, OrganAriralInternal, OrganAriralMetabolizer ]
+  parent: [ OrganBaseLungs, OrganAriralInternal, OrganHumanMetabolizer ]
   id: OrganAriralLungs
 
 - type: entity
-  parent: [ OrganBaseHeart, OrganAriralInternal]
+  parent: [ OrganBaseHeart, OrganAriralInternal, OrganAriralMetabolizer ]
   id: OrganAriralHeart
-  components:
-  - type: Metabolizer
-    metabolizerTypes: [ Ariral ]
 
 - type: entity
-  parent: [ OrganBaseStomach, OrganAriralInternal ]
+  parent: [ OrganBaseStomach, OrganAriralInternal, OrganAriralMetabolizer ]
   id: OrganAriralStomach
-  components:
-  - type: Metabolizer
-    metabolizerTypes: [ Ariral ]
 
 - type: entity
-  parent: [ OrganBaseLiver, OrganAriralInternal, OrganAriralMetabolizer ]
+  parent: [ OrganBaseLiver, OrganAriralInternal ]
   id: OrganAriralLiver
 
 - type: entity
-  parent: [ OrganBaseKidneys, OrganAriralInternal, OrganAriralMetabolizer ]
+  parent: [ OrganBaseKidneys, OrganAriralInternal ]
   id: OrganAriralKidneys

--- a/Resources/Prototypes/_Wega/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/_Wega/Reagents/Consumable/Food/food.yml
@@ -46,3 +46,25 @@
   - !type:PlantAdjustHealth
     amount: 0.75
   pricePerUnit: 2
+
+- type: reagent
+  parent: Shrimp
+  id: CookedShrimp
+  name: reagent-name-cooked-shrimp
+  desc: reagent-desc-cooked-shrimp
+  color: "#102e0d"
+  metabolisms:
+    Digestion:
+      effects:
+      - !type:SatiateHunger
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Vampire ]
+          inverted: true
+      - !type:AdjustReagent
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Vampire ]
+          inverted: true
+        reagent: Protein
+        amount: 0.5

--- a/Resources/Prototypes/_Wega/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Wega/Recipes/Reactions/single_reagent.yml
@@ -1,0 +1,9 @@
+- type: reaction
+  id: shrimpCooking
+  impact: Low
+  minTemp: 347
+  reactants:
+    Shrimp:
+      amount: 0.5
+  products:
+    CookedShrimp: 0.5


### PR DESCRIPTION
## Описание PR
Дело было вечером, в расшире делать нечего

Унатхи теперь могут есть салаты, овощи, супы и пасты
<img width="302" height="170" alt="iguana-eating" src="https://github.com/user-attachments/assets/998ec6af-189b-4233-804e-b7c3ca849ba1" />
<img width="190" height="250" alt="TeguLizard (1)" src="https://github.com/user-attachments/assets/51bbf9e7-9b40-4bb2-9bac-96ef4a288d63" />
Ариралы больше не травятся от непрожаренных протеинов как это и должно быть
А сами креветки теперь можно приготовить для безопасного употребления всеми расами

## Почему / Баланс
По предложениям игроков, с отравлением ариралов от креветок вообще баг 
https://discord.com/channels/1286594744432066562/1524499104535810220
https://discord.com/channels/1286594744432066562/1530978932831162449
https://discord.com/channels/1286594744432066562/1531206061741310042

## Технические детали
У унатхов в прототипе расширены теги для specialDigestible
Поскольку у паст нет своих тегов им добавлен ReptilianFood
Непрожаренные протеины у нас токсины, а не еда, поэтому сердцу ариралов заменён метаболизм с человеческого на ариральский
Добавлен реагент приготовленной креветки и реакция готовки при нагреве креветки
Приготовленная креветка добавляет протеины, вместо травящих, непрожаренных

**Список изменений**
:cl:
- add: Креветки теперь можно приготовить!
- add: Расширена диета унатхов!
- fix: Ариралы больше не отравляются при поедании сырых креветок!
