### PR TITLE
Слаймолюды, но по старому

### DIFF
--- a/Content.Client/Humanoid/MarkingsViewModel.cs
+++ b/Content.Client/Humanoid/MarkingsViewModel.cs
@@ -226,6 +226,11 @@ public sealed partial class MarkingsViewModel
         if (!groupProto.Appearances.TryGetValue(layer, out var appearance))
             return true;
 
+        // Corvax-Wega-Customize-start
+        if (markingProto.Sprites.Count > 1)
+            return true;
+        // Corvax-Wega-Customize-end
+
         return !appearance.MatchSkin;
     }
 
@@ -384,7 +389,35 @@ public sealed partial class MarkingsViewModel
         if (markingIdx == -1)
             return;
 
-        markings[markingIdx] = markings[markingIdx].WithColorAt(colorIndex, color);
+        // Corvax-Wega-Customize-start
+        var existingMarking = markings[markingIdx];
+        var proto = _prototype.Index(markingId);
+
+        var isGradient = proto.Sprites.Count > 1;
+        if (isGradient)
+        {
+            var matchSkin = false;
+            if (_organData.TryGetValue(organ, out var organData)
+                && _prototype.TryIndex(organData.Group, out var groupProto))
+            {
+                if (groupProto.Appearances.TryGetValue(layer, out var appearance))
+                    matchSkin = appearance.MatchSkin;
+            }
+
+            if (matchSkin && colorIndex == 0)
+                return;
+
+            markings[markingIdx] = existingMarking.WithColorAt(colorIndex, color);
+        }
+        else
+        {
+            if (!IsMarkingColorCustomizable(organ, layer, markingId))
+                return;
+
+            markings[markingIdx] = existingMarking.WithColorAt(colorIndex, color);
+        }
+        // Corvax-Wega-Customize-End
+
         MarkingsChanged?.Invoke(organ, layer);
     }
 

--- a/Content.Shared/Body/SharedVisualBodySystem.cs
+++ b/Content.Shared/Body/SharedVisualBodySystem.cs
@@ -48,6 +48,11 @@ public abstract partial class SharedVisualBodySystem : EntitySystem
 
         foreach (var (marking, prototype) in forcedColors)
         {
+            // Corvax-Wega-Customize-start
+            var isGradient = prototype.Sprites.Count > 1;
+            var originalColors = marking.MarkingColors.ToList();
+            // Corvax-Wega-Customize-end
+
             var colors = MarkingColoring.GetMarkingLayerColors(
                 prototype,
                 skinColor,
@@ -58,10 +63,32 @@ public abstract partial class SharedVisualBodySystem : EntitySystem
             {
                 Forced = marking.Forced,
             };
+
+            // Corvax-Wega-Customize-Edit-start
             if (appearances.GetValueOrDefault(prototype.BodyPart) is { MatchSkin: true } appearance && skinColor is { } color)
             {
-                markingWithColor = markingWithColor.WithColor(color.WithAlpha(appearance.LayerAlpha));
+                if (isGradient)
+                {
+                    var newColors = new List<Color>();
+                    newColors.Add(color.WithAlpha(appearance.LayerAlpha));
+
+                    for (int i = 1; i < markingWithColor.MarkingColors.Count; i++)
+                    {
+                        var layerColor = i < originalColors.Count ? originalColors[i] : markingWithColor.MarkingColors[i];
+                        newColors.Add(layerColor.WithAlpha(appearance.LayerAlpha));
+                    }
+
+                    markingWithColor = new Marking(marking.MarkingId, newColors)
+                    {
+                        Forced = marking.Forced,
+                    };
+                }
+                else
+                {
+                    markingWithColor = markingWithColor.WithColor(color.WithAlpha(appearance.LayerAlpha));
+                }
             }
+            // Corvax-Wega-Customize-Edit-end
             ret.Add(markingWithColor);
         }
 

--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -46,10 +46,10 @@
     # Corvax-Sponsors-end
   appearances:
     enum.HumanoidVisualLayers.Hair:
-      layerAlpha: 0.72
-      # matchSkin: true # Corvax-Wega-Edit
+      layerAlpha: 0.5 # Corvax-Wega-Edit
+      matchSkin: true
     enum.HumanoidVisualLayers.FacialHair:
-      layerAlpha: 0.72
+      layerAlpha: 0.5 # Corvax-Wega-Edit
       matchSkin: true
 
 - type: entity


### PR DESCRIPTION
## Описание PR
Возвращена обратно прозрачность волос у слаймолюдов в тот вид, что была в игре ранее
Теперь они более аутентичные для своей расы

Также градиендирование волос слаймолюдов теперь также учитывает прозрачность и не позволяет менять цвет первого слоя (который следует за цветом кожи как задумано у расы)

## Почему / Баланс
Вернул стареньких слаймов, да

## Медиа
https://github.com/user-attachments/assets/e792c3c2-b8cf-46a3-a5b4-9d7d308a71db
