### PR TITLE
Fix BloodCult ritual targets

### DIFF
--- a/Content.Server/_Wega/BloodCult/BloodCultSystem.Runes.cs
+++ b/Content.Server/_Wega/BloodCult/BloodCultSystem.Runes.cs
@@ -378,7 +378,7 @@ public sealed partial class BloodCultSystem
 
     private bool IsSpecialTarget(EntityUid target)
     {
-        return HasComp<MindShieldComponent>(target)
+        return HasComp<MindShieldStatusComponent>(target)
             || HasComp<BibleUserComponent>(target)
             || HasComp<BloodCultObjectComponent>(target)
             || HasComp<VeilCultistComponent>(target);
@@ -386,15 +386,16 @@ public sealed partial class BloodCultSystem
 
     private bool IsConvertibleTarget(EntityUid target)
     {
-        return !HasComp<MindShieldComponent>(target)
+        return !HasComp<MindShieldStatusComponent>(target)
             && !HasComp<BibleUserComponent>(target)
             && !HasComp<SyntheticOperatedComponent>(target)
-            && !HasComp<VeilCultistComponent>(target);
+            && !HasComp<VeilCultistComponent>(target)
+            && !HasComp<BloodCultObjectComponent>(target);
     }
 
     private bool IsRegularTarget(EntityUid target)
     {
-        return !HasComp<MindShieldComponent>(target)
+        return !HasComp<MindShieldStatusComponent>(target)
             && !HasComp<BibleUserComponent>(target)
             && !HasComp<SyntheticOperatedComponent>(target)
             && !HasComp<VeilCultistComponent>(target);

--- a/Content.Server/_Wega/BloodCult/BloodCultSystem.Runes.cs
+++ b/Content.Server/_Wega/BloodCult/BloodCultSystem.Runes.cs
@@ -376,9 +376,15 @@ public sealed partial class BloodCultSystem
         }
     }
 
+    private bool IsMindshielded(EntityUid target)
+    {
+        return TryComp<MindShieldStatusComponent>(target, out var shield)
+            && shield.IsMindshielded; // changelings or fake shields
+    }
+
     private bool IsSpecialTarget(EntityUid target)
     {
-        return HasComp<MindShieldStatusComponent>(target)
+        return IsMindshielded(target)
             || HasComp<BibleUserComponent>(target)
             || HasComp<BloodCultObjectComponent>(target)
             || HasComp<VeilCultistComponent>(target);
@@ -386,7 +392,7 @@ public sealed partial class BloodCultSystem
 
     private bool IsConvertibleTarget(EntityUid target)
     {
-        return !HasComp<MindShieldStatusComponent>(target)
+        return !IsMindshielded(target)
             && !HasComp<BibleUserComponent>(target)
             && !HasComp<SyntheticOperatedComponent>(target)
             && !HasComp<VeilCultistComponent>(target)
@@ -395,7 +401,7 @@ public sealed partial class BloodCultSystem
 
     private bool IsRegularTarget(EntityUid target)
     {
-        return !HasComp<MindShieldStatusComponent>(target)
+        return !IsMindshielded(target)
             && !HasComp<BibleUserComponent>(target)
             && !HasComp<SyntheticOperatedComponent>(target)
             && !HasComp<VeilCultistComponent>(target);

--- a/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -29,6 +29,7 @@ using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Zombies;
+using Content.Shared.Roles.Jobs;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
@@ -58,6 +59,7 @@ namespace Content.Server.GameTicking.Rules
         [Dependency] private ObjectivesSystem _objectives = default!;
         [Dependency] private TargetObjectiveSystem _target = default!;
         [Dependency] private MetaDataSystem _meta = default!;
+        [Dependency] private SharedJobSystem _job = default!;
 
         public readonly ProtoId<NpcFactionPrototype> BloodCultNpcFaction = "BloodCult";
 
@@ -187,23 +189,51 @@ namespace Content.Server.GameTicking.Rules
 
         private EntityUid? FindNewRandomTarget(BloodCultRuleComponent cult, EntityUid excludedTarget)
         {
-            var candidates = new List<EntityUid>();
-            var query = EntityQueryEnumerator<HumanoidProfileComponent, ActorComponent>();
-            while (query.MoveNext(out var uid, out _, out _))
+            var mindShieldCandidates = new List<EntityUid>();
+
+            var mindShieldQuery = EntityQueryEnumerator<
+                HumanoidProfileComponent,
+                ActorComponent,
+                MindShieldStatusComponent>();
+
+            while (mindShieldQuery.MoveNext(out var uid, out _, out _, out var status))
             {
-                if (uid == excludedTarget || cult.SelectedTargets.Contains(uid)
+                if (!status.IsMindshielded
+                    || uid == excludedTarget
+                    || cult.SelectedTargets.Contains(uid)
                     || HasComp<BloodCultistComponent>(uid)
                     || HasComp<BloodCultObjectComponent>(uid))
                     continue;
 
-                candidates.Add(uid);
+                mindShieldCandidates.Add(uid);
             }
 
-            if (candidates.Count == 0)
+            if (mindShieldCandidates.Count > 0)
+            {
+                var index = _random.Next(0, mindShieldCandidates.Count);
+                return mindShieldCandidates[index];
+            }
+
+            var globalCandidates = new List<EntityUid>();
+
+            var globalQuery = EntityQueryEnumerator<HumanoidProfileComponent, ActorComponent>();
+
+            while (globalQuery.MoveNext(out var uid, out _, out _))
+            {
+                if (uid == excludedTarget
+                    || cult.SelectedTargets.Contains(uid)
+                    || HasComp<BloodCultistComponent>(uid)
+                    || HasComp<BloodCultObjectComponent>(uid))
+                    continue;
+
+                globalCandidates.Add(uid);
+            }
+
+            if (globalCandidates.Count == 0)
                 return null;
 
-            var index = _random.Next(0, candidates.Count);
-            return candidates[index];
+            var globalIndex = _random.Next(0, globalCandidates.Count);
+            return globalCandidates[globalIndex];
         }
 
         private void ReplaceTargetForAllCultists(EntityUid oldTarget, EntityUid newTarget)
@@ -221,8 +251,12 @@ namespace Content.Server.GameTicking.Rules
             foreach (var objectiveUid in replacedObjectives)
             {
                 _target.SetTarget(objectiveUid, newTarget);
-                _meta.SetEntityName(objectiveUid, Loc.GetString("objective-condition-blood-ritual-person-title",
-                    ("targetName", Name(newTarget))));
+                var jobName = _job.MindTryGetJobName(newTarget);
+
+                _meta.SetEntityName(objectiveUid, Loc.GetString(
+                    "objective-condition-blood-ritual-person-title",
+                    ("targetName", Name(newTarget)),
+                    ("job", jobName)));
             }
         }
 
@@ -269,8 +303,12 @@ namespace Content.Server.GameTicking.Rules
                     continue;
 
                 _target.SetTarget(objective.Value, target);
-                _meta.SetEntityName(objective.Value, Loc.GetString("objective-condition-blood-ritual-person-title",
-                    ("targetName", Name(target)))); // <see cref="ObjectiveAssignedEvent"/> here doesn't worked, or i'm stupid
+                var jobName = _job.MindTryGetJobName(target);
+
+                _meta.SetEntityName(objective.Value, Loc.GetString(
+                    "objective-condition-blood-ritual-person-title",
+                    ("targetName", Name(target)), // <see cref="ObjectiveAssignedEvent"/> here doesn't worked, or i'm stupid
+                    ("job", jobName)));
                 _mind.AddObjective(mindId, mind, objective.Value);
             }
         }

--- a/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared.Popups;
 using Content.Shared.Zombies;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.Surgery.Components;
+using Content.Shared.Mind.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
@@ -254,7 +255,13 @@ namespace Content.Server.GameTicking.Rules
             foreach (var objectiveUid in replacedObjectives)
             {
                 _target.SetTarget(objectiveUid, newTarget);
-                var jobName = _job.MindTryGetJobName(newTarget);
+                var jobName = Loc.GetString("generic-unknown-title");
+
+                if (TryComp<MindContainerComponent>(newTarget, out var mindContainer)
+                    && mindContainer.Mind is { } targetMindId)
+                {
+                    jobName = _job.MindTryGetJobName(targetMindId);
+                }
 
                 _meta.SetEntityName(objectiveUid, Loc.GetString(
                     "objective-condition-blood-ritual-person-title",
@@ -306,12 +313,19 @@ namespace Content.Server.GameTicking.Rules
                     continue;
 
                 _target.SetTarget(objective.Value, target);
-                var jobName = _job.MindTryGetJobName(target);
+                var jobName = Loc.GetString("generic-unknown-title");
+
+                if (TryComp<MindContainerComponent>(target, out var mindContainer)
+                    && mindContainer.Mind is { } targetMindId)
+                {
+                    jobName = _job.MindTryGetJobName(targetMindId);
+                }
 
                 _meta.SetEntityName(objective.Value, Loc.GetString(
                     "objective-condition-blood-ritual-person-title",
-                    ("targetName", Name(target)), // <see cref="ObjectiveAssignedEvent"/> here doesn't worked, or i'm stupid
+                    ("targetName", Name(target)),
                     ("job", jobName)));
+
                 _mind.AddObjective(mindId, mind, objective.Value);
             }
         }

--- a/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -30,6 +30,7 @@ using Content.Shared.NPC.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Zombies;
 using Content.Shared.Roles.Jobs;
+using Content.Shared.Surgery.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
@@ -131,10 +132,12 @@ namespace Content.Server.GameTicking.Rules
 
             var mindShieldCandidates = new List<EntityUid>();
             var enumerator = EntityQueryEnumerator<HumanoidProfileComponent, MindShieldStatusComponent>();
-
             while (enumerator.MoveNext(out var uid, out _, out var status))
             {
                 if (!status.IsMindshielded)
+                    continue;
+
+                if (HasComp<SyntheticOperatedComponent>(uid))
                     continue;
 
                 if (HasComp<BloodCultistComponent>(uid))

--- a/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
+++ b/Content.Server/_Wega/GameTicking/Rules/BloodCultRuleSystem.cs
@@ -128,9 +128,18 @@ namespace Content.Server.GameTicking.Rules
             cult.SelectedTargets.Clear();
 
             var mindShieldCandidates = new List<EntityUid>();
-            var enumerator = EntityQueryEnumerator<MindShieldComponent>();
-            while (enumerator.MoveNext(out var uid, out _))
+            var enumerator = EntityQueryEnumerator<HumanoidProfileComponent, MindShieldStatusComponent>();
+
+            while (enumerator.MoveNext(out var uid, out _, out var status))
+            {
+                if (!status.IsMindshielded)
+                    continue;
+
+                if (HasComp<BloodCultistComponent>(uid))
+                    continue;
+
                 mindShieldCandidates.Add(uid);
+            }
 
             if (mindShieldCandidates.Count >= 2)
             {

--- a/Resources/Locale/ru-RU/_wega/objectives/conditions/bloodcult.ftl
+++ b/Resources/Locale/ru-RU/_wega/objectives/conditions/bloodcult.ftl
@@ -1,1 +1,1 @@
-objective-condition-blood-ritual-person-title = Пренисите в жертву { $targetName } во славу Геометриви Крови.
+objective-condition-blood-ritual-person-title = Пренисите в жертву { $targetName }, {CAPITALIZE($job)} во славу Геометриви Крови.


### PR DESCRIPTION
# Описание PR
Исправил выбор целей кровавого культа, вместе с ним и ритуал для призыва божества

## Почему / Баланс
Совсем недавно выпал режим культа, а целями выбрались сами импланты в сущностях, из-за рефактора(судя по всему) `MindShieldComponent`, он остался только на импланте, а на куклах используется только `MindShieldStatusComponent`, к тому же, при условии уничтожения необходимых целей в "слепую", `BloodRitualConductedEvent()` всё равно не поднимался и 9-ая руна ритуала не появлялась

## Технические детали
Смена `MindShieldComponent` на `MindShieldStatusComponent`

Дополнительное условие `!HasComp<BloodCultObjectComponent>(target)` в методе `IsConvertibleTarget()` чтобы **цель** культа **без МЩ** невозможно было обратить в культиста

Небольшое изменение метода `SelectRandomTargets()`, чтобы предотвратить выбор цели самого импланта вместо гуманоида (обе сущности имеют `MindShieldStatusComponent`)

Изменение поиска и замены новой цели в случае ухода первой в крио, теперь приоритетнее на замену выбирается цель с МЩ, в противном случае без него

Теперь к описанию цели добавилась её должность для удобства

## Медиа
<img width="492" height="37" alt="Screenshot_425" src="https://github.com/user-attachments/assets/253734dc-7c02-411f-aca2-d2c5172638d0" />
<img width="339" height="213" alt="Screenshot_427" src="https://github.com/user-attachments/assets/d9a6af19-b6ec-4747-a5f6-67ffd4f53f20" />
<img width="667" height="130" alt="Screenshot_428" src="https://github.com/user-attachments/assets/deb8d448-0915-4307-8ee3-4b68b3dfcea4" />
