### PR TITLE
Нерф брони боргов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -130,8 +130,6 @@
 # Corvax-Wega-Start
     - type: Inventory
       templateId: borgDutch
-    - type: EmpResistance
-      strengthMultiplier: 0
     - type: MobThresholds # tankier
       thresholds:
         0: Alive
@@ -204,6 +202,9 @@
         params:
           volume: -6
 # Corvax-Wega-Start
+    - type: LockingWhitelist # so it can help the mothership borging other xenoborgs
+      blacklist:
+        null
     - type: Inventory
       templateId: borgDutch
     - type: EmpResistance

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -581,7 +581,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMicroreactor # PowerCellHyper Corvax-Wega
+        startingItem: PowerCellHyper # PowerCellHyper Corvax-Wega
 
 - type: entity
   id: PlayerBorgSyndicateAssaultGhostRole

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -612,12 +612,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
+        Blunt: 0.8
+        Slash: 0.8
         Heat: 0.8
       flatReductions:
-        Slash: 5
-        Blunt: 5
+        Slash: 2
+        Blunt: 2
   # Corvax-Wega-End
   - type: ItemBorgModule
     hands:
@@ -1621,7 +1621,6 @@
     hands:
     # Corvax-Wega-Robot-Edit-start
     - item: SyndicateJawsOfLife
-    - item: SyndicateDrill
     - hand:
         emptyRepresentative: NukeDisk
         emptyLabel: borg-slot-nukedisk-empty # Corvax-Wega-Add
@@ -1689,10 +1688,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.1
-        Slash: 0.1
-        Piercing: 0.1
-        Heat: 0.2
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.5
+        Heat: 0.5
   - type: BorgModuleWhitelist
     moduleBlacklist:
       tags:

--- a/Resources/Prototypes/_Wega/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_Wega/Entities/Mobs/Player/silicon.yml
@@ -43,7 +43,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellMicroreactor # PowerCellHyper Corvax-Wega
+        startingItem: PowerCellHyper # PowerCellHyper Corvax-Wega
 
 - type: entity
   id: PlayerBorgSyndicateMedicalGhostRole

--- a/Resources/Prototypes/_Wega/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Wega/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -877,10 +877,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.7
+        Blunt: 0.85
+        Slash: 0.85
+        Piercing: 0.85
+        Heat: 0.85
   - type: BorgModuleWhitelist
     moduleBlacklist:
       tags:
@@ -927,7 +927,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.4
+        Heat: 0.7
   - type: BorgModuleWhitelist
     moduleBlacklist:
       tags:
@@ -977,7 +977,7 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.4
+        Piercing: 0.7
         Heat: 0.9
   - type: BorgModuleWhitelist
     moduleBlacklist:
@@ -1022,10 +1022,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.3
-        Slash: 0.3
+        Blunt: 0.6
+        Slash: 0.6
         Piercing: 0.8
-        Heat: 0.3
+        Heat: 0.8
   - type: BorgModuleWhitelist
     moduleBlacklist:
       tags:
@@ -1519,13 +1519,6 @@
     moduleBlacklist:
       tags:
       - BorgModuleLethalSyndi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.7
-        Heat: 0.7
   - type: ItemBorgModule
     hands:
     - item: BorgWeaponSniperHristovAdvanced
@@ -1559,10 +1552,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.4
-        Heat: 0.4
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.75
+        Heat: 0.75
   - type: BorgModuleWhitelist
     moduleBlacklist:
       tags:
@@ -1651,6 +1644,13 @@
         whitelist:
           tags:
           - Itemborg
+    - item: TurboItemRechargerXenoborg
+    - hand:
+        emptyRepresentative: PowerCellHigh
+        emptyLabel: borg-slot-powercell-empty
+        whitelist:
+          components:
+          - PowerCell
     - item: SprayBottleEthanol
       hand:
         emptyRepresentative: SprayBottle

--- a/Resources/Prototypes/_Wega/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Wega/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1552,10 +1552,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.7
+        Heat: 0.7
   - type: BorgModuleWhitelist
     moduleBlacklist:
       tags:

--- a/Resources/Prototypes/_Wega/silicon-laws.yml
+++ b/Resources/Prototypes/_Wega/silicon-laws.yml
@@ -30,22 +30,22 @@
 
 - type: siliconLaw
   id: NTDefault1B
-  order: 3
+  order: 2
   lawString: law-ntdefault-1
 
 - type: siliconLaw
   id: NTDefault2B
-  order: 4
+  order: 3
   lawString: law-ntdefault-2
 
 - type: siliconLaw
   id: NTDefault3B
-  order: 5
+  order: 4
   lawString: law-ntdefault-3
 
 - type: siliconLaw
   id: NTDefault4B
-  order: 6
+  order: 5
   lawString: law-ntdefault-4
 
 - type: siliconLawset
@@ -92,7 +92,7 @@
   
 - type: siliconLaw
   id: SecLaw7
-  order: 6
+  order: 7
   lawString: law-ntdefault-4
   
 - type: siliconLawset


### PR DESCRIPTION
## Описание PR
1. Устойчевость станционных боргов к урону понижена в два раза, по сравнение с теми аналогами, которые те замещают, шахтерский борг теперь срезает только 20 процентов порезов, ушибов и ожогов. 
2. Штурмовой борг теперь имеет такую стату защиты
А, Снайпа - 10 процентов защиты от брута и ожогов + 100 рефлекта
Б. ЦРка - 30 процентов защиты от брута и ожогов + 50 рефлекта
В. Л6 - 50 процентов защиты от брута и ожогов
3. Штурмовой борг потерял эми защиту и борги синдиката потеряли микрореакторную, теперь там гиппер батарея. 
4. Медицинский борг теперь имеет в модуле хирургии турбозарядник и руку под батареи для зарядки боргов.